### PR TITLE
Update Travis CI to work with new test layout and external imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
+  - sudo apt-get update
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then sudo apt-get install python3-numpy; fi
   - sudo apt-get install openbabel libopenbabel-dev swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ virtualenv:
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then sudo apt-get install python3-numpy; fi
-  - sudo apt-get install libopenbabel4
+  - sudo apt-get install openbabel libopenbabel-dev swig
   - pip install -r requirements.txt
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python setup.py install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy python-openbabel; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then sudo apt-get install python3-numpy; fi
+  - sudo apt-get install libopenbabel4
+  - pip install -r requirements.txt
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python setup.py install; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python setup.py install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python setup.py install; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python setup.py install; fi
 script:
-  - cd test && python test_bridge.py
-  - cd test && python test_parser.py
-  - cd test && python test_data.py --status --terse
+  - cd test
+  - python test_bridge.py
+  - python test_parser.py
+  - python test_data.py --status --terse
   - cd ../data && bash regression_download.sh
   - cd ../test && python run_regressions.py --status --traceback

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 virtualenv:
   system_site_packages: true
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then sudo apt-get install python-numpy python-openbabel; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then sudo apt-get install python3-numpy; fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then python setup.py install; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openbabel

--- a/src/cclib/bridge/__init__.py
+++ b/src/cclib/bridge/__init__.py
@@ -12,7 +12,7 @@
 
 try:
     import openbabel
-except Exception:
+except ImportError:
     pass
 else:
     from .cclib2openbabel import makeopenbabel
@@ -25,6 +25,8 @@ else:
     from .cclib2pyquante import makepyquante
 
 try:
-    from .cclib2biopython import makebiopython
+    import Bio
 except ImportError:
     pass
+else:
+    from .cclib2biopython import makebiopython

--- a/src/cclib/bridge/cclib2biopython.py
+++ b/src/cclib/bridge/cclib2biopython.py
@@ -10,7 +10,12 @@
 
 """Bridge for using cclib data in biopython (http://biopython.org)."""
 
-from Bio.PDB.Atom import Atom
+try:
+    from Bio.PDB.Atom import Atom
+except ImportError:
+    # Fail silently for now.
+    pass
+
 from cclib.parser.utils import PeriodicTable
 
 

--- a/src/cclib/bridge/cclib2openbabel.py
+++ b/src/cclib/bridge/cclib2openbabel.py
@@ -10,7 +10,11 @@
 
 """Bridge between cclib data and openbabel (http://openbabel.org)."""
 
-import openbabel as ob
+try:
+    import openbabel as ob
+except ImportError:
+    # Fail silently for now.
+    pass
 
 from cclib.parser.data import ccData
 

--- a/src/cclib/bridge/cclib2pyquante.py
+++ b/src/cclib/bridge/cclib2pyquante.py
@@ -17,7 +17,8 @@ import sys
 try:
     from PyQuante.Molecule import Molecule
 except ImportError:
-    print("PyQuante could not be imported.")
+    # Fail silently for now.
+    pass
 
 
 def makepyquante(atomcoords, atomnos, charge=0, mult=1):


### PR DESCRIPTION
I finally see how this is going to work. Everything looks good to me, so I refreshed the Travis build for https://github.com/cclib/cclib/pull/190, and it's failing on some silly stuff.

1. The script commands in `.travis.yml` for `cd` aren't working: https://travis-ci.org/cclib/cclib/jobs/58387892#L290
2. The import for Open Babel isn't working. Right now, it's set so that if any of the imports of external dependencies fails, it's silent.

There doesn't seem to be an Ubuntu package for the Python 3 Open Babel module, and I can't remember if `python-openbabel` will work for both versions. For now, it's being installed via `pip`.

In the future, these failed imports should be logged or printed to stderr.