### PR TITLE
Closed shell property modifications

### DIFF
--- a/src/cclib/method/__init__.py
+++ b/src/cclib/method/__init__.py
@@ -21,4 +21,5 @@ from .mbo import MBO
 from .mpa import MPA
 from .nuclear import Nuclear
 from .opa import OPA
+from .orbitals import Orbitals
 from .volume import Volume

--- a/src/cclib/method/density.py
+++ b/src/cclib/method/density.py
@@ -27,20 +27,20 @@ class Density(Method):
 
         # Call the __init__ method of the superclass.
         super(Density, self).__init__(data, progress, loglevel, logname)
-        
+
     def __str__(self):
         """Return a string representation of the object."""
-        return "Density matrix of" % (self.data)
+        return "Density matrix of " + self.data.__str__()
 
     def __repr__(self):
         """Return a representation of the object."""
         return 'Density matrix("%s")' % (self.data)
-    
+
     def calculate(self, fupdate=0.05):
         """Calculate the density matrix."""
-    
+
         # Do we have the needed info in the data object?
-        if not hasattr(self.data, "mocoeffs"): 
+        if not hasattr(self.data, "mocoeffs"):
             self.logger.error("Missing mocoeffs")
             return False
         if not hasattr(self.data,"nbasis"):

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of cclib (http://cclib.github.io), a library for parsing
+# and interpreting the results of computational chemistry packages.
+#
+# Copyright (C) 2016, the cclib development team
+#
+# The library is free software, distributed under the terms of
+# the GNU Lesser General Public version 2.1 or later. You should have
+# received a copy of the license along with cclib. You can also access
+# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+
+"""Analyses related to orbitals."""
+
+import logging
+
+import numpy
+
+from .calculationmethod import Method
+
+
+class Orbitals(Method):
+    """A class for orbital related methods."""
+    
+    def __init__(self, data, progress=None, \
+                 loglevel=logging.INFO, logname="Log"):
+
+        # Call the __init__ method of the superclass.
+        super(Orbitals, self).__init__(data, progress, loglevel, logname)
+        self.fragresults = None
+        
+    def __str__(self):
+        """Return a string representation of the object."""
+        return "Orbitals"
+
+    def __repr__(self):
+        """Return a representation of the object."""
+        return "Orbitals"
+
+    def closed_shell(self):
+        """Return Boolean indicating if system is closed shell."""
+
+        # Restricted calculation will have one set of orbitals and are
+        # therefore closed shell by definition.
+        if len(self.data.mocoeffs) == 1:
+            assert len(self.data.moenergies) == 1
+            return True
+
+        # If there are beta orbitals, we can assume the system is
+        # closed shell if the orbital energies are identical within
+        # numerical accuracy.
+        diff = numpy.abs(self.data.moenergies[1] - self.data.moenergies[0])
+        precision = 10e-6
+        return any(diff < precision)
+
+
+if __name__ == "__main__":
+    import doctest, orbitals
+    doctest.testmod(orbitals, verbose=False)

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -46,6 +46,7 @@ class Orbitals(Method):
         # Both unrestricted and restricted open-shell calculations
         # may have two HOMOs.
         else:
+            precision = 10e-6
             # In the case where the two HOMOs are different (any spin
             # multiplicity other than singlet), the system is
             # open-shell by definition.
@@ -54,11 +55,14 @@ class Orbitals(Method):
             # In the case where the two HOMOs are identical, it is not
             # sufficient to just check MO energies. The way we
             # differentiate between a restricted calculation run as
-            # unrestricted and a broken-symmetry singlet is the
-            # difference in MO coefficients.
-            else:
-                precision = 10e-6
+            # unrestricted and a broken-symmetry or open-shell singlet
+            # is the difference in MO coefficients.
+            elif hasattr(self.data, 'mocoeffs'):
                 return numpy.allclose(*self.data.mocoeffs, atol=precision)
+            # The two HOMOs are identical, but no MO coefficients are
+            # present, so check the energies.
+            else:
+                return numpy.allclose(*self.data.moenergies, atol=precision)
 
 
 if __name__ == "__main__":

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -49,9 +49,8 @@ class Orbitals(Method):
         # If there are beta orbitals, we can assume the system is
         # closed shell if the orbital energies are identical within
         # numerical accuracy.
-        diff = numpy.abs(self.data.moenergies[1] - self.data.moenergies[0])
         precision = 10e-6
-        return any(diff < precision)
+        return numpy.allclose(*self.data.moenergies, atol=precision)
 
 
 if __name__ == "__main__":

--- a/src/cclib/method/orbitals.py
+++ b/src/cclib/method/orbitals.py
@@ -21,14 +21,13 @@ from .calculationmethod import Method
 
 class Orbitals(Method):
     """A class for orbital related methods."""
-    
+
     def __init__(self, data, progress=None, \
                  loglevel=logging.INFO, logname="Log"):
 
         # Call the __init__ method of the superclass.
         super(Orbitals, self).__init__(data, progress, loglevel, logname)
-        self.fragresults = None
-        
+
     def __str__(self):
         """Return a string representation of the object."""
         return "Orbitals"
@@ -40,17 +39,26 @@ class Orbitals(Method):
     def closed_shell(self):
         """Return Boolean indicating if system is closed shell."""
 
-        # Restricted calculation will have one set of orbitals and are
-        # therefore closed shell by definition.
-        if len(self.data.mocoeffs) == 1:
-            assert len(self.data.moenergies) == 1
+        # If there is only one HOMO, the system is closed-shell by
+        # definition.
+        if len(self.data.homos) == 1:
             return True
-
-        # If there are beta orbitals, we can assume the system is
-        # closed shell if the orbital energies are identical within
-        # numerical accuracy.
-        precision = 10e-6
-        return numpy.allclose(*self.data.moenergies, atol=precision)
+        # Both unrestricted and restricted open-shell calculations
+        # may have two HOMOs.
+        else:
+            # In the case where the two HOMOs are different (any spin
+            # multiplicity other than singlet), the system is
+            # open-shell by definition.
+            if self.data.homos[0] != self.data.homos[1]:
+                return False
+            # In the case where the two HOMOs are identical, it is not
+            # sufficient to just check MO energies. The way we
+            # differentiate between a restricted calculation run as
+            # unrestricted and a broken-symmetry singlet is the
+            # difference in MO coefficients.
+            else:
+                precision = 10e-6
+                return numpy.allclose(*self.data.mocoeffs, atol=precision)
 
 
 if __name__ == "__main__":

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -302,7 +302,7 @@ class ccData(object):
 
     @property
     def closed_shell(self):
-        return orbitals.orbitals(self).closed_shell()
+        return orbitals.Orbitals(self).closed_shell()
 
 
 class ccData_optdone_bool(ccData):

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -16,6 +16,8 @@
 import numpy
 from collections import namedtuple
 
+from cclib.method import orbitals
+
 
 class ccData(object):
     """Stores data extracted by cclib parsers
@@ -297,6 +299,9 @@ class ccData(object):
     def writexyz(self, filename=None):
         """Write parsed attributes to an XML file."""
         return self.write(filename=filename, outputtype='xyz')
+
+    def closed_shell(self):
+        return orbitals.orbitals(self).closed_shell()
 
 
 class ccData_optdone_bool(ccData):

--- a/src/cclib/parser/data.py
+++ b/src/cclib/parser/data.py
@@ -300,6 +300,7 @@ class ccData(object):
         """Write parsed attributes to an XML file."""
         return self.write(filename=filename, outputtype='xyz')
 
+    @property
     def closed_shell(self):
         return orbitals.orbitals(self).closed_shell()
 

--- a/test/data/testSP.py
+++ b/test/data/testSP.py
@@ -133,6 +133,10 @@ class GenericSPTest(unittest.TestCase):
         """Is the index of the HOMO equal to 34?"""
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34],"i"), "%s != array([34],'i')" % numpy.array_repr(self.data.homos))
 
+    def testorbitals(self):
+        """Is the molecule closed-shell?"""
+        self.assertTrue(self.data.closed_shell)
+
     def testscfvaluetype(self):
         """Are scfvalues and its elements the right type??"""
         self.assertEquals(type(self.data.scfvalues),type([]))

--- a/test/data/testSPun.py
+++ b/test/data/testSPun.py
@@ -59,6 +59,10 @@ class GenericSPunTest(unittest.TestCase):
         msg = "%s != array([34,33],'i')" % numpy.array_repr(self.data.homos)
         numpy.testing.assert_array_equal(self.data.homos, numpy.array([34,33],"i"), msg)
 
+    def testorbitals(self):
+        """Is the molecule open-shell?"""
+        self.assertFalse(self.data.closed_shell)
+
     def testmoenergies(self):
         """Are the dims of the moenergies equals to 2 x nmo?"""
         self.assertEquals(len(self.data.moenergies), 2)

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -42,20 +42,21 @@ class UnrestrictedCalculationTest(unittest.TestCase):
         self.assertFalse(Orbitals(self.data).closed_shell())
 
 
-class RestrictedOpenShellCalculationTest(unittest.TestCase):
-    """Check restricted open-shell calculation."""
-    def setUp(self):
-        self.data, self.logfile = getdatafile(DALTON, "basicDALTON-2015", "dvb_sp_un_hf.out")
+# class RestrictedOpenShellCalculationTest(unittest.TestCase):
+#     """Check restricted open-shell calculation."""
+#     def setUp(self):
+#         self.data, self.logfile = getdatafile(DALTON, "basicDALTON-2015", "dvb_sp_un_hf.out")
 
-    def test_closed_shell(self):
-        self.assertFalse(Orbitals(self.data).closed_shell())
+#     def test_closed_shell(self):
+#         self.assertFalse(Orbitals(self.data).closed_shell())
 
 
 # TODO: add a case (regression) with an unrestricted calculation for a closed shell system.
 # For example, in regressions: Gaussian/Gaussian03/Mo4OSibdt2
 
-
-tests = [RestrictedCalculationTest, UnrestrictedCalculationTest, RestrictedOpenShellCalculationTest]
+# Don't enable the restricted open-shell test until the parsers have
+# been updated.
+tests = [RestrictedCalculationTest, UnrestrictedCalculationTest]
 
 
 if __name__ == "__main__":

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -1,0 +1,53 @@
+# This file is part of cclib (http://cclib.github.io), a library for parsing
+# and interpreting the results of computational chemistry packages.
+#
+# Copyright (C) 2016 the cclib development team
+#
+# The library is free software, distributed under the terms of
+# the GNU Lesser General Public version 2.1 or later. You should have
+# received a copy of the license along with cclib. You can also access
+# the full license online at http://www.gnu.org/copyleft/lgpl.html.
+
+"""Test the various population analyses (MPA, LPA, CSPA) in cclib"""
+
+import sys
+import os
+import logging
+import unittest
+
+import numpy
+
+sys.path.append("..")
+from test_data import getdatafile
+from cclib.method import Orbitals
+from cclib.parser import Gaussian
+
+
+class RestrictedCalculationTest(unittest.TestCase):
+    """Check RHF calculation."""
+    def setUp(self):
+        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_sp.out")
+
+    def test_closed_shell(self):
+        self.assertTrue(Orbitals(self.data).closed_shell())
+
+
+class UnrestrictedCalculationTest(unittest.TestCase):
+    """Check RHF calculation."""
+    def setUp(self):
+        self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_un_sp.log")
+
+    def test_closed_shell(self):
+        self.assertFalse(Orbitals(self.data).closed_shell())
+
+
+# TODO: add a case (regression) with an unrestricted calculation for a closed shell system.
+
+
+tests = [RestrictedCalculationTest, UnrestrictedCalculationTest]
+
+
+if __name__ == "__main__":
+    for test in tests:
+        thistest = unittest.makeSuite(test)
+        unittest.TextTestRunner(verbosity=2).run(thistest)

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -20,11 +20,12 @@ import numpy
 sys.path.append("..")
 from test_data import getdatafile
 from cclib.method import Orbitals
+from cclib.parser import DALTON
 from cclib.parser import Gaussian
 
 
 class RestrictedCalculationTest(unittest.TestCase):
-    """Check retricted calculation."""
+    """Check restricted calculation."""
     def setUp(self):
         self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_sp.out")
 
@@ -41,11 +42,20 @@ class UnrestrictedCalculationTest(unittest.TestCase):
         self.assertFalse(Orbitals(self.data).closed_shell())
 
 
+class RestrictedOpenShellCalculationTest(unittest.TestCase):
+    """Check restricted open-shell calculation."""
+    def setUp(self):
+        self.data, self.logfile = getdatafile(DALTON, "basicDALTON-2015", "dvb_sp_un_hf.out")
+
+    def test_closed_shell(self):
+        self.assertFalse(Orbitals(self.data).closed_shell())
+
+
 # TODO: add a case (regression) with an unrestricted calculation for a closed shell system.
 # For example, in regressions: Gaussian/Gaussian03/Mo4OSibdt2
 
 
-tests = [RestrictedCalculationTest, UnrestrictedCalculationTest]
+tests = [RestrictedCalculationTest, UnrestrictedCalculationTest, RestrictedOpenShellCalculationTest]
 
 
 if __name__ == "__main__":

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -24,7 +24,7 @@ from cclib.parser import Gaussian
 
 
 class RestrictedCalculationTest(unittest.TestCase):
-    """Check RHF calculation."""
+    """Check retricted calculation."""
     def setUp(self):
         self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_sp.out")
 
@@ -33,7 +33,7 @@ class RestrictedCalculationTest(unittest.TestCase):
 
 
 class UnrestrictedCalculationTest(unittest.TestCase):
-    """Check RHF calculation."""
+    """Check unrestricted calculation."""
     def setUp(self):
         self.data, self.logfile = getdatafile(Gaussian, "basicGaussian09", "dvb_un_sp.log")
 
@@ -42,6 +42,7 @@ class UnrestrictedCalculationTest(unittest.TestCase):
 
 
 # TODO: add a case (regression) with an unrestricted calculation for a closed shell system.
+# For example, in regressions: Gaussian/Gaussian03/Mo4OSibdt2
 
 
 tests = [RestrictedCalculationTest, UnrestrictedCalculationTest]

--- a/test/method/testorbitals.py
+++ b/test/method/testorbitals.py
@@ -42,21 +42,19 @@ class UnrestrictedCalculationTest(unittest.TestCase):
         self.assertFalse(Orbitals(self.data).closed_shell())
 
 
-# class RestrictedOpenShellCalculationTest(unittest.TestCase):
-#     """Check restricted open-shell calculation."""
-#     def setUp(self):
-#         self.data, self.logfile = getdatafile(DALTON, "basicDALTON-2015", "dvb_sp_un_hf.out")
+class RestrictedOpenShellCalculationTest(unittest.TestCase):
+    """Check restricted open-shell calculation."""
+    def setUp(self):
+        self.data, self.logfile = getdatafile(DALTON, "basicDALTON-2015", "dvb_sp_un_hf.out")
 
-#     def test_closed_shell(self):
-#         self.assertFalse(Orbitals(self.data).closed_shell())
+    def test_closed_shell(self):
+        self.assertFalse(Orbitals(self.data).closed_shell())
 
 
 # TODO: add a case (regression) with an unrestricted calculation for a closed shell system.
 # For example, in regressions: Gaussian/Gaussian03/Mo4OSibdt2
 
-# Don't enable the restricted open-shell test until the parsers have
-# been updated.
-tests = [RestrictedCalculationTest, UnrestrictedCalculationTest]
+tests = [RestrictedCalculationTest, UnrestrictedCalculationTest, RestrictedOpenShellCalculationTest]
 
 
 if __name__ == "__main__":

--- a/test/test_method.py
+++ b/test/test_method.py
@@ -20,5 +20,6 @@ if __name__ == "__main__":
     from testcda import *
     from testmbo import *
     from testnuclear import *
+    from testorbitals import *
     from testpopulation import *
     unittest.main()


### PR DESCRIPTION
- Made sure that the method tests are run.
- Added property tests to `testSP` and `testSPun`.
- Handle the restricted open-shell case.

This will fail under Travis for two reasons:
- Unrestricted calculations aren't being properly recognized by DALTON. The solution is to rebase or merge with master, which contains the fixes. I didn't want to pollute this PR by doing that yet.
- There is a regression test (`OrcaSPunTest_charge0`) for a calculation that is properly closed-shell but run as unrestricted. `closed_shell` is correctly True, but the test inherits from `testSPun`. The solution is to override `testorbitals` as is done in https://github.com/cclib/cclib-data/pull/46.
